### PR TITLE
パンくずリストの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,3 +77,4 @@ gem 'pry-rails'
 gem "haml-rails"
 gem 'erb2haml'
 gem "jquery-rails"
+gem 'gretel'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,8 @@ GEM
       sassc (>= 1.11)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    gretel (3.0.9)
+      rails (>= 3.1.0)
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt
@@ -269,6 +271,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   erb2haml
   font-awesome-sass (~> 5.4.1)
+  gretel
   haml-rails
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,6 +17,7 @@
 @import "modules/form";
 
 @import "modules/header";
+@import "modules/breadcrumb";
 @import "modules/slider";
 
 @import "modules/item";

--- a/app/assets/stylesheets/modules/_breadcrumb.scss
+++ b/app/assets/stylesheets/modules/_breadcrumb.scss
@@ -1,0 +1,66 @@
+.breadcrumb{
+  &.bread-head{
+    position: relative;
+    border-top: 1px solid #eeeeee;
+    background: #fff;
+    box-shadow: 0 3px 3px 0 rgba(0,0,0,.16);
+  }
+
+  &.bread-bottom{
+    background: #f5f5f5;
+    box-shadow: none;
+  }
+
+  ul{
+    display: flex;
+    padding: 16px;
+    font-size: 16px;
+    white-space: nowrap;
+    overflow: auto;
+
+    @include tb{
+      overflow: visible;
+      width: 700px;
+      margin: 0 auto;
+      padding: 16px 0;
+      white-space: normal;
+    }
+
+    @include pc{
+      width: 1020px;
+    }
+
+    li{
+      font-size: 14px;
+      line-height: 1.2;
+
+      @include tb{
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      &:before{
+        content: ">";
+        margin: 0 14px;
+        font-weight: normal;
+        color: #888888;
+      }
+
+      &:first-child{
+        &:before{
+          content: "";
+          margin: 0;
+          padding-left: 11px;
+        }
+      }
+
+      &:last-child{
+        font-weight: 600;
+      }
+    }
+  }
+
+  a{
+    color: #333;
+  }
+}

--- a/app/assets/stylesheets/modules/_breadcrumb.scss
+++ b/app/assets/stylesheets/modules/_breadcrumb.scss
@@ -9,6 +9,7 @@
   &.bread-bottom{
     background: #f5f5f5;
     box-shadow: none;
+    border-top: 1px solid #eeeeee;
   }
 
   ul{

--- a/app/assets/stylesheets/page/mypage/_user-check.scss
+++ b/app/assets/stylesheets/page/mypage/_user-check.scss
@@ -1,7 +1,4 @@
 .content{
-  background: #fff;
-  float:right;
-  width:700px;
   &__head{
     font-size: 24px;
     padding: 8px 24px;

--- a/app/assets/stylesheets/page/mypage/_users.scss
+++ b/app/assets/stylesheets/page/mypage/_users.scss
@@ -8,16 +8,14 @@ ul {
 }
 
 .container{
+  display: flex;
   width: 1020px;
   margin: 40px auto 0;
   overflow: auto;
   padding: 0 0 40px;
 }
 
-
 .content{
-  float:right;
-  width:700px;
   &__profile{
     position: relative;
     background-image: image-url("user-bg.jpg");
@@ -151,6 +149,3 @@ ul {
     color: #ccc;
   }
 }
-  
-
-

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,7 @@
 class ItemsController < ApplicationController
   def index
   end
+
+  def show
+  end
 end

--- a/app/views/cards/index.html.haml
+++ b/app/views/cards/index.html.haml
@@ -1,4 +1,6 @@
 - @page_title = '支払い方法'
+- breadcrumb :card
+
 = content_for :header do
   = render 'shared/header'
 = content_for :app_banner do

--- a/app/views/cards/new.html.haml
+++ b/app/views/cards/new.html.haml
@@ -1,4 +1,6 @@
-- @page_title = '支払い方法'
+- @page_title = 'クレジットカード情報入力'
+- breadcrumb :cardcreate
+
 = content_for :header do
   = render 'shared/header'
 = content_for :app_banner do

--- a/app/views/exhibit/index.html.haml
+++ b/app/views/exhibit/index.html.haml
@@ -1,4 +1,5 @@
 - @page_title = '出品'
+
 .container
   = render partial: 'shared/header-exhibit'
   %main.main

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -164,16 +164,4 @@
       .item__content
         - for i in 1..6
           = render 'shared/item-box'
-  %nav.bread-crumbs__pos-bottom
-    %ul
-      %li.itemscope__itemtype
-        = link_to 'メルカリ', root_path
-        %i.fa.fa-angle-right
-      %li.itemscope__itemtype
-        %span.itemprop 居るとこ
-  = render partial:'shared/app-banner'
-  = render partial: 'shared/footer'
-  .item-btn__float-area
-    .item-buy__btn
-      = link_to "購入画面に進む", purchase_index_path
 = render 'shared/breadcrumb-items'

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,0 +1,13 @@
+- @page_title = 'テスト商品'
+- breadcrumb :items
+
+= content_for :header do
+  = render 'shared/header'
+= content_for :app_banner do
+  = render 'shared/app-banner'
+= content_for :footer do
+  = render 'shared/footer'
+= content_for :sell_btn do
+  = render 'shared/sell-btn'
+
+= render 'shared/breadcrumb-items'

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -10,7 +10,7 @@
 = content_for :sell_btn do
   = render 'shared/sell-btn'
 
-.item-box__container  
+.item-box__container
   %main.main
     %section.main__container__sell-item-box
       %h1.sell-item__name
@@ -19,7 +19,7 @@
         .sell-item__photo
           .sell-item__photo__all
             .sell-item__photo__main
-              = image_tag "sell-sample.jpg", alt: "", class: "" 
+              = image_tag "sell-sample.jpg", alt: "", class: ""
             .sell-item__photo__dots
               .sell-item__photo__dot.active
                 .sell-item__photo__dot__inner
@@ -27,7 +27,7 @@
               - for i in 1..4
                 = render 'items/item-photo'
               - for i in 1..2
-                = render 'items/item-photo'             
+                = render 'items/item-photo'
         .sell-item__price-box.display-none
           %span.sell-item__price¥499
           %span.sell-item__tax（税込）
@@ -50,7 +50,7 @@
                   .sell-item__user-ratings
                     .icon-bad
                       %i.fa.fa-frown
-                      %span 0 
+                      %span 0
             %tr
               %th カテゴリー
               %td
@@ -62,7 +62,7 @@
                 .sub-category
                   = link_to "#" do
                     %i.fa.fa-angle-right
-                    %span サブカテ2                 
+                    %span サブカテ2
             %tr
               %th ブランド
               %td
@@ -81,7 +81,7 @@
               %td らくらくメルカリ便
             %tr
               %th 配送元地域
-              %td 
+              %td
                 = link_to "大阪府"
             %tr
               %th 発送日の目安
@@ -89,9 +89,9 @@
         .sell-item__price-box
           %span.sell-item__price ¥499
           %span.sell-item__tax  (税込)
-          %span.sell-item__shipping-fee 送料込み   
+          %span.sell-item__shipping-fee 送料込み
         .item-buy__btn
-          = link_to "購入画面に進む", purchase_index_path 
+          = link_to "購入画面に進む", purchase_index_path
       .item-description
         %p.item-description__inner
           ほげほげほげほげほげほげほげ
@@ -125,31 +125,31 @@
             %p
               相手のことを考え丁寧なコメントを心がけましょう。不快な言葉遣いなどは利用制限や退会処分となることがあります。
             %textarea{name: 'body', class: '.textarea-default'}
-            %button{type: 'submit', class: 'btn-bray'} 
-              %span コメントする 
+            %button{type: 'submit', class: 'btn-bray'}
+              %span コメントする
     %ul.nav-item__links
       %li.nav-item__link-prev
         = link_to '#' do
-          %i.fa.fa-angle-left 
-          前へ         
+          %i.fa.fa-angle-left
+          前へ
       %li.nav-item__link-next
         = link_to '#' do
-          次へ 
+          次へ
           %i.fa.fa-angle-right
     .item-social-media__box
       .text-center
       %ul.sosial-media__box
         %li
-          = link_to 'https://ja-jp.facebook.com/' do 
+          = link_to 'https://ja-jp.facebook.com/' do
             %i.fab.fa-facebook-square
         %li
-          = link_to 'https://twitter.com/home?lang=ja' do 
+          = link_to 'https://twitter.com/home?lang=ja' do
             %i.fab.fa-twitter-square
         %li
-          = link_to 'https://line.me/ja/' do 
+          = link_to 'https://line.me/ja/' do
             %i.fab.fa-line
         %li
-          = link_to 'https://www.pinterest.jp/' do 
+          = link_to 'https://www.pinterest.jp/' do
             %i.fab.fa-pinterest-square
   .items__user-profile
     %section.items-box__container
@@ -158,7 +158,7 @@
       .item__content
         - for i in 1..6
           = render 'shared/item-box'
-    %section.items-box__container     
+    %section.items-box__container
       %h2.items-box__head
         = link_to '関連ブランドその他の出品', '#'
       .item__content
@@ -172,7 +172,7 @@
       %li.itemscope__itemtype
         %span.itemprop 居るとこ
   = render partial:'shared/app-banner'
-  = render partial: 'shared/footer'      
+  = render partial: 'shared/footer'
   .item-btn__float-area
     .item-buy__btn
       = link_to "購入画面に進む", purchase_index_path

--- a/app/views/purchase/index.html.haml
+++ b/app/views/purchase/index.html.haml
@@ -1,4 +1,5 @@
 - @page_title = '購入を確定'
+
 .container
   = render partial: 'shared/header-exhibit'
   %main.main

--- a/app/views/shared/_breadcrumb-items.html.haml
+++ b/app/views/shared/_breadcrumb-items.html.haml
@@ -1,0 +1,10 @@
+- breadcrumbs do |links|
+  - if links.any?
+    %nav.breadcrumb.bread-bottom
+      %ul
+        - links.each do |link|
+          = content_tag :li do
+            - if link.current?
+              = content_tag :span, link.text
+            - else
+              = link_to link.text, link.url

--- a/app/views/shared/_breadcrumb.html.haml
+++ b/app/views/shared/_breadcrumb.html.haml
@@ -1,0 +1,2 @@
+%nav.breadcrumb.bread-head
+  = breadcrumbs class: nil, style: :ul

--- a/app/views/shared/_header-logined.html.haml
+++ b/app/views/shared/_header-logined.html.haml
@@ -1,41 +1,40 @@
-%body
-  %header.header
-    .header__container
-      .header__logo
-        %h1
-          = link_to root_path do
-            = image_tag 'logo.svg', size: '134x36', alt: 'mercari'
-      .header__user-nav-logined-460
-        = link_to '#', class: '' do
-          %i.far.fa-bell
-        = link_to '#', class: '' do
-          %i.fa.fa-check
-        = link_to mypage_path, class: '' do
-          = image_tag 'member_photo_noimage_thumb.png', alt:'', width: '32'
-      .header__search
-        = form_with urls: '#', class: 'header__form' do |form|
-          = text_field_tag :keyword, "" , class: 'header__form__input', placeholder: 'なにかお探しですか？'
-          = button_tag type: 'submit', class: 'header__form__icon' do
-            %i.fa.fa-search
-      %ul.header__navigation-logined
-        %li#category-menu.category-menu
-          = link_to '#' do
-            %i.fa.fa-list.navigation-icon
-            %span カテゴリーから探す
-        %li#brand-menu.category-menu
-          = link_to '#' do
-            %i.fa.fa-tag.navigation-icon
-            %span ブランドから探す
-      .header__user-nav-logined-768
-        = link_to '#', class: '' do
-          %i.far.fa-heart
-          %span いいね！一覧
-        = link_to '#', class: '' do
-          %i.far.fa-bell
-          %span お知らせ
-        = link_to '#', class: '' do
-          %i.fa.fa-check
-          %span やることリスト
-        = link_to mypage_path, class: '' do
-          = image_tag 'member_photo_noimage_thumb.png', alt:'', width: '32'
-          %span マイページ
+%header.header
+  .header__container
+    .header__logo
+      %h1
+        = link_to root_path do
+          = image_tag 'logo.svg', size: '134x36', alt: 'mercari'
+    .header__user-nav-logined-460
+      = link_to '#', class: '' do
+        %i.far.fa-bell
+      = link_to '#', class: '' do
+        %i.fa.fa-check
+      = link_to mypage_path, class: '' do
+        = image_tag 'member_photo_noimage_thumb.png', alt:'', width: '32'
+    .header__search
+      = form_with urls: '#', class: 'header__form' do |form|
+        = text_field_tag :keyword, "" , class: 'header__form__input', placeholder: 'なにかお探しですか？'
+        = button_tag type: 'submit', class: 'header__form__icon' do
+          %i.fa.fa-search
+    %ul.header__navigation-logined
+      %li#category-menu.category-menu
+        = link_to '#' do
+          %i.fa.fa-list.navigation-icon
+          %span カテゴリーから探す
+      %li#brand-menu.category-menu
+        = link_to '#' do
+          %i.fa.fa-tag.navigation-icon
+          %span ブランドから探す
+    .header__user-nav-logined-768
+      = link_to '#', class: '' do
+        %i.far.fa-heart
+        %span いいね！一覧
+      = link_to '#', class: '' do
+        %i.far.fa-bell
+        %span お知らせ
+      = link_to '#', class: '' do
+        %i.fa.fa-check
+        %span やることリスト
+      = link_to mypage_path, class: '' do
+        = image_tag 'member_photo_noimage_thumb.png', alt:'', width: '32'
+        %span マイページ

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -1,30 +1,30 @@
-%body
-  %header.header
-    .header__container
-      .header__logo
-        %h1
-          = link_to root_path do
-            = image_tag 'logo.svg', size: '134x36', alt: 'mercari'
-      .header__user-nav
-        = link_to '#', class: 'signup-btn' do
-          新規会員登録
-        = link_to '#', class: 'login-btn' do
-          ログイン
-      .header__search
-        = form_with urls: '#', class: 'header__form' do |form|
-          = text_field_tag :keyword, "" , class: 'header__form__input', placeholder: 'なにかお探しですか？'
-          = button_tag type: 'submit', class: 'header__form__icon' do
-            -# %i.fas.fa-search
-            %i.fa.fa-search
-      %ul.header__navigation
-        %li#category-menu.category-menu
-          = link_to '#' do
-            -# %i.fas.fa-list.navigation-icon
-            %i.fa.fa-list.navigation-icon
-            %span カテゴリーから探す
-        %li#brand-menu.category-menu
-          = link_to '#' do
-            -# %i.fas.fa-tag.navigation-icon
-            %i.fa.fa-tag.navigation-icon
-            %span ブランドから探す
-
+%header.header
+  .header__container
+    .header__logo
+      %h1
+        = link_to root_path do
+          = image_tag 'logo.svg', size: '134x36', alt: 'mercari'
+    .header__user-nav
+      = link_to '#', class: 'signup-btn' do
+        新規会員登録
+      = link_to mypage_profile_index_path, class: 'login-btn' do
+        ログイン
+    .header__search
+      = form_with urls: '#', class: 'header__form' do |form|
+        = text_field_tag :keyword, "" , class: 'header__form__input', placeholder: 'なにかお探しですか？'
+        = button_tag type: 'submit', class: 'header__form__icon' do
+          -# %i.fas.fa-search
+          %i.fa.fa-search
+    %ul.header__navigation
+      %li#category-menu.category-menu
+        = link_to '#' do
+          -# %i.fas.fa-list.navigation-icon
+          %i.fa.fa-list.navigation-icon
+          %span カテゴリーから探す
+      %li#brand-menu.category-menu
+        = link_to '#' do
+          -# %i.fas.fa-tag.navigation-icon
+          %i.fa.fa-tag.navigation-icon
+          %span ブランドから探す
+- unless controller.controller_name == "items"
+  = render 'shared/breadcrumb'

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -7,7 +7,7 @@
     .header__user-nav
       = link_to '#', class: 'signup-btn' do
         新規会員登録
-      = link_to mypage_profile_index_path, class: 'login-btn' do
+      = link_to mypage_path, class: 'login-btn' do
         ログイン
     .header__search
       = form_with urls: '#', class: 'header__form' do |form|

--- a/app/views/user_profiles/index.html.haml
+++ b/app/views/user_profiles/index.html.haml
@@ -1,4 +1,6 @@
 - @page_title = 'プロフィール'
+- breadcrumb :profile
+
 = content_for :header do
   = render 'shared/header'
 = content_for :app_banner do

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -10,53 +10,53 @@
 = content_for :sell_btn do
   = render 'shared/sell-btn'
 
-%main.container.clearfix
+.mypage-container
   .content
-    %section.content__profile
-      = link_to '#', class: 'content__profile-link' do
-        %figure.my-img
-          =image_tag src="member_photo_noimage_thumb.png", id: "my-img", alt: "", height: "60",  width: "60"
-        %h2.user-name
-          name
-        .content__profile__information
-          .information
-            評価
-            %span.bold
-              0
-          .information
-            出品数
-            %span.bold
-              0
+    %section.content__wrap
+      .content__profile
+        = link_to '#', class: 'content__profile-link' do
+          %figure.my-img
+            =image_tag src="member_photo_noimage_thumb.png", id: "my-img", alt: "", height: "60",  width: "60"
+          %h2.user-name
+            name
+          .content__profile__information
+            .information
+              評価
+              %span.bold
+                0
+            .information
+              出品数
+              %span.bold
+                0
 
-    .tabs
-      %input#notice{checked: "checked", name: "tab_item", type: "radio"}/
-      %label.tabs__item{for: "notice"} お知らせ
-      %input#dolist{name: "tab_item", type: "radio"}/
-      %label.tabs__item{for: "dolist"} やることリスト
-      #notice_content.tab_content
-        = render partial:'shared/tab-content'
-        = render partial:'shared/tab-content'
-      #dolist_content.tab_content
-        = render partial:'shared/tab-content'
-      %li.tab-list
-        = link_to '#', class: 'tab-list-link' do
-          一覧をみる
-
-    .buy-items
-      %h2.buy-items__head
-        購入した商品
       .tabs
-        %input#trading{checked: "checked", name: "tabs-item", type: "radio"}/
-        %label.tabs__item{for: "trading"} 取引中
-        %input#trade{name: "tabs-item", type: "radio"}/
-        %label.tabs__item{for: "trade"} 過去の取引
-        #trading_content.tab_content
-          .not-item
-            %li.not-item__content
-              取引中のアイテムがありません
-        #trade_content.tab_content
-          .not-item
-            %li.not-item__content
-              過去に取引した商品はありません
-  .side_bar
-    = render 'shared/sidebar-mypage'
+        %input#notice{checked: "checked", name: "tab_item", type: "radio"}/
+        %label.tabs__item{for: "notice"} お知らせ
+        %input#dolist{name: "tab_item", type: "radio"}/
+        %label.tabs__item{for: "dolist"} やることリスト
+        #notice_content.tab_content
+          = render partial:'shared/tab-content'
+          = render partial:'shared/tab-content'
+        #dolist_content.tab_content
+          = render partial:'shared/tab-content'
+        %li.tab-list
+          = link_to '#', class: 'tab-list-link' do
+            一覧をみる
+    %section.content__wrap
+      .buy-items
+        %h2.buy-items__head
+          購入した商品
+        .tabs
+          %input#trading{checked: "checked", name: "tabs-item", type: "radio"}/
+          %label.tabs__item{for: "trading"} 取引中
+          %input#trade{name: "tabs-item", type: "radio"}/
+          %label.tabs__item{for: "trade"} 過去の取引
+          #trading_content.tab_content
+            .not-item
+              %li.not-item__content
+                取引中のアイテムがありません
+          #trade_content.tab_content
+            .not-item
+              %li.not-item__content
+                過去に取引した商品はありません
+  = render 'shared/sidebar-mypage'

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,5 +1,6 @@
+- @page_title = 'マイページ'
+- breadcrumb :mypage
 
-- @page_title = 'マイページ' 
 = content_for :header do
   = render 'shared/header'
 = content_for :app_banner do

--- a/app/views/users/logout.html.haml
+++ b/app/views/users/logout.html.haml
@@ -1,4 +1,6 @@
 - @page_title = 'ログアウト'
+- breadcrumb :logout
+
 = content_for :header do
   = render 'shared/header'
 = content_for :app_banner do

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,28 @@
+crumb :root do
+  link "Home", root_path
+end
+
+# crumb :projects do
+#   link "Projects", projects_path
+# end
+
+# crumb :project do |project|
+#   link project.name, project_path(project)
+#   parent :projects
+# end
+
+# crumb :project_issues do |project|
+#   link "Issues", project_issues_path(project)
+#   parent :project, project
+# end
+
+# crumb :issue do |issue|
+#   link issue.title, issue_path(issue)
+#   parent :project_issues, issue.project
+# end
+
+# If you want to split your breadcrumbs configuration over multiple files, you
+# can create a folder named `config/breadcrumbs` and put your configuration
+# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
+# folder are loaded and reloaded automatically when you change them, just like
+# this file (`config/breadcrumbs.rb`).

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,5 +1,37 @@
 crumb :root do
-  link "Home", root_path
+  link "メルカリ", root_path
+end
+
+# マイページ
+crumb :mypage do
+  link "マイページ", mypage_path
+  parent :root
+end
+
+crumb :profile do
+  link "プロフィール", mypage_profile_index_path
+  parent :mypage
+end
+
+crumb :card do
+  link "支払い方法", mypage_cards_path
+  parent :mypage
+end
+
+crumb :cardcreate do
+  link "クレジットカード情報入力", new_mypage_card_path
+  parent :card
+end
+
+crumb :logout do
+  link "ログアウト", logout_mypage_path
+  parent :mypage
+end
+
+# パンくずリスト 商品ページ非表示テスト
+crumb :items do
+  link "テスト商品", items_path
+  parent :root
 end
 
 # crumb :projects do
@@ -20,9 +52,3 @@ end
 #   link issue.title, issue_path(issue)
 #   parent :project_issues, issue.project
 # end
-
-# If you want to split your breadcrumbs configuration over multiple files, you
-# can create a folder named `config/breadcrumbs` and put your configuration
-# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
-# folder are loaded and reloaded automatically when you change them, just like
-# this file (`config/breadcrumbs.rb`).

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -30,7 +30,7 @@ end
 
 # 商品ページ
 crumb :items do
-  link "テスト商品", item_path(1)
+  link "商品詳細", item_path(1)
   parent :root
 end
 

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -28,9 +28,9 @@ crumb :logout do
   parent :mypage
 end
 
-# パンくずリスト 商品ページ非表示テスト
+# 商品ページ
 crumb :items do
-  link "テスト商品", items_path
+  link "テスト商品", item_path(1)
   parent :root
 end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
 
   root 'items#index'
   
-  resource :items, only: [:show]
+  resources :items, only: [:show]
   resources :exhibit, only: [:index]
   resources :purchase, only: [:index]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
 
   root 'items#index'
   
+  resource :items, only: [:show]
   resources :exhibit, only: [:index]
   resources :purchase, only: [:index]
 


### PR DESCRIPTION
#WHAT
・パンくずリストの実装
・本番環境確認での各ページへのアクセスリンクを設ける

#WHY
・ユーザー利用時のページ間移動の快適化のため
・確認時のアドレス直接入力状況の改善

![パンくずリスト](https://i.gyazo.com/cfcbd91975abf49b6b85968871ed8a4b.png)

## 商品ページ用のパンくずリストについて
見本のメルカリを確認したところ、商品ページのみフッター直上にパンくずを実装しておりました。
商品一覧ページのみ別個の表示をするために仮の商品ページとアクション、ルートを作成しており、この辺りは後で削除するなり調整するなりします。

![パンくずリスト2](https://i.gyazo.com/43b0a8486b598cad154321f1409d7707.jpg)